### PR TITLE
Implemented condition to ensure a twitter link is an actual tweet before replacing

### DIFF
--- a/lib/fxtwitter_bot/fixer.ex
+++ b/lib/fxtwitter_bot/fixer.ex
@@ -1,5 +1,6 @@
 defmodule FxtwitterBot.Fixer do
-  @twitter_regex ~r/https?:\/\/(www\.|mobile\.)?twitter.com/
+  @twitter_regex ~r/https?:\/\/(www\.|mobile\.)?twitter.com\/.+\/status/
+  @twitter_replace ~r/https?:\/\/(www\.|mobile\.)?twitter.com/
   @twitter_fix "https://fxtwitter.com"
 
   @instagram_regex ~r/https?:\/\/(www\.)?instagram.com/
@@ -8,10 +9,11 @@ defmodule FxtwitterBot.Fixer do
   @tiktok_regex ~r/https?:\/\/vm.tiktok.com/
   @tiktok_fix "https://vm.dstn.to"
 
-  @all_regex [@twitter_regex, @instagram_regex, @tiktok_regex]
-  @all_fixes [@twitter_fix, @instagram_fix, @tiktok_fix]
+  @all_regex    [@twitter_regex, @instagram_regex, @tiktok_regex]
+  @all_replaces [@twitter_replace, @instagram_regex, @tiktok_regex]
+  @all_fixes    [@twitter_fix, @instagram_fix, @tiktok_fix]
 
-  @regex_to_fix Enum.zip(@all_regex, @all_fixes)
+  @regex_to_fix Enum.zip(@all_replaces, @all_fixes)
 
   def maybe_fix(text) when is_binary(text) do
     if Enum.any?(@all_regex, &String.match?(text, &1)) do

--- a/test/fxtwitter_bot/fixer_test.exs
+++ b/test/fxtwitter_bot/fixer_test.exs
@@ -5,20 +5,20 @@ defmodule FxtwitterBot.FixerTest do
 
   describe "maybe_fix/1" do
     test "works" do
-      assert {:ok, result} = Fixer.maybe_fix("https://twitter.com/user")
-      assert result == "https://fxtwitter.com/user"
+      assert {:ok, result} = Fixer.maybe_fix("https://twitter.com/rickroll/status/1093270903599726593")
+      assert result == "https://fxtwitter.com/rickroll/status/1093270903599726593"
 
-      assert {:ok, result} = Fixer.maybe_fix("https://www.twitter.com/user")
-      assert result == "https://fxtwitter.com/user"
+      assert {:ok, result} = Fixer.maybe_fix("https://www.twitter.com/rickroll/status/1093270903599726593")
+      assert result == "https://fxtwitter.com/rickroll/status/1093270903599726593"
 
-      assert {:ok, result} = Fixer.maybe_fix("http://twitter.com/user")
-      assert result == "https://fxtwitter.com/user"
+      assert {:ok, result} = Fixer.maybe_fix("http://twitter.com/rickroll/status/1093270903599726593")
+      assert result == "https://fxtwitter.com/rickroll/status/1093270903599726593"
 
-      assert {:ok, result} = Fixer.maybe_fix("http://www.twitter.com/user")
-      assert result == "https://fxtwitter.com/user"
+      assert {:ok, result} = Fixer.maybe_fix("http://www.twitter.com/rickroll/status/1093270903599726593")
+      assert result == "https://fxtwitter.com/rickroll/status/1093270903599726593"
 
-      assert {:ok, result} = Fixer.maybe_fix("http://mobile.twitter.com/user")
-      assert result == "https://fxtwitter.com/user"
+      assert {:ok, result} = Fixer.maybe_fix("http://mobile.twitter.com/rickroll/status/1093270903599726593")
+      assert result == "https://fxtwitter.com/rickroll/status/1093270903599726593"
 
       assert {:ok, result} =
                Fixer.maybe_fix(
@@ -30,20 +30,20 @@ defmodule FxtwitterBot.FixerTest do
 
       text = """
       Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-      https://twitter.com/user
+      https://twitter.com/rickroll/status/1093270903599726593
 
-      Suspendisse elementum https://twitter.com/user ante vitae
+      Suspendisse elementum https://twitter.com/rickroll/status/1093270903599726593 ante vitae
 
-      dapibus convallis. Phasellus scelerisque mollis arcu suscipit https://twitter.com/user
+      dapibus convallis. Phasellus scelerisque mollis arcu suscipit https://twitter.com/rickroll/status/1093270903599726593
       """
 
       expected = """
       Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-      https://fxtwitter.com/user
+      https://fxtwitter.com/rickroll/status/1093270903599726593
 
-      Suspendisse elementum https://fxtwitter.com/user ante vitae
+      Suspendisse elementum https://fxtwitter.com/rickroll/status/1093270903599726593 ante vitae
 
-      dapibus convallis. Phasellus scelerisque mollis arcu suscipit https://fxtwitter.com/user
+      dapibus convallis. Phasellus scelerisque mollis arcu suscipit https://fxtwitter.com/rickroll/status/1093270903599726593
       """
 
       assert {:ok, result} = Fixer.maybe_fix(text)

--- a/test/fxtwitter_bot_test.exs
+++ b/test/fxtwitter_bot_test.exs
@@ -4,8 +4,8 @@ defmodule FxtwitterBotTest do
 
   describe "maybe_fix/1" do
     test "works" do
-      assert {:ok, result} = FxtwitterBot.maybe_fix("https://twitter.com/user")
-      assert result == "https://fxtwitter.com/user"
+      assert {:ok, result} = FxtwitterBot.maybe_fix("https://twitter.com/rickroll/status/1093270903599726593")
+      assert result == "https://fxtwitter.com/rickroll/status/1093270903599726593"
     end
 
     test "no match" do


### PR DESCRIPTION
Updated the regex to ensure a Twitter link is an actual tweet so urls like 'twitter.com/username' aren't replaced.